### PR TITLE
Update to 1.7.0

### DIFF
--- a/SOURCES/xcp-ng-xapi-plugins-1.6.1.tar.gz
+++ b/SOURCES/xcp-ng-xapi-plugins-1.6.1.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:35551b866eab36a557cb29a6cd99d457880c3c8ac2c31c82da32ae610308abd9
-size 20628

--- a/SOURCES/xcp-ng-xapi-plugins-1.7.0.tar.gz
+++ b/SOURCES/xcp-ng-xapi-plugins-1.7.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:537a06efaae624ff933cc40b96e922118cb2d9730b37b57a7a7e98b952c2d547
+size 28480

--- a/SPECS/xcp-ng-xapi-plugins.spec
+++ b/SPECS/xcp-ng-xapi-plugins.spec
@@ -1,7 +1,7 @@
 Summary: XAPI additional plugins for XCP-ng
 Name: xcp-ng-xapi-plugins
-Version: 1.6.1
-Release: 3%{?dist}
+Version: 1.7.0
+Release: 1%{?dist}
 URL: https://github.com/xcp-ng/xcp-ng-xapi-plugins
 Source0: https://github.com/xcp-ng/xcp-ng-xapi-plugins/archive/v%{version}/%{name}-%{version}.tar.gz
 License: AGPLv3
@@ -32,6 +32,11 @@ install SOURCES/etc/xapi.d/plugins/xcpngutils/*.py %{buildroot}/etc/xapi.d/plugi
 %dir /var/lib/xcp-ng-xapi-plugins
 
 %changelog
+* Fri Dec 17 2021 Benjamin Reis <benjamin.reis@vates.fr> - 1.7.0-1
+- Fix lock in updater plugin (See: https://github.com/xcp-ng/xcp/issues/523)
+- Normalize plugins output
+- Add plugin to display return of lsblk
+
 * Wed Jul 01 2020 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.6.1-3
 - Rebuild for XCP-ng 8.2.0
 


### PR DESCRIPTION
- Fix lock in updater plugin (See: https://github.com/xcp-ng/xcp/issues/523)
- Normalize plugins output
- Add plugin to display return of lsblk

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>