### PR TITLE
XCP-ng 8.2: Update to 1.8.0

### DIFF
--- a/SOURCES/xcp-ng-xapi-plugins-1.7.2.tar.gz
+++ b/SOURCES/xcp-ng-xapi-plugins-1.7.2.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:202a86b57c3e51d64f31ec73e7e5884202b743f89939c7ade6f0e47ac0d6f3a6
-size 28490

--- a/SOURCES/xcp-ng-xapi-plugins-1.8.0.tar.gz
+++ b/SOURCES/xcp-ng-xapi-plugins-1.8.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d609557bef31038c5412ca0a0dbb05a68371dbb6c222bece226a17b75b19585b
+size 32647

--- a/SPECS/xcp-ng-xapi-plugins.spec
+++ b/SPECS/xcp-ng-xapi-plugins.spec
@@ -1,6 +1,6 @@
 Summary: XAPI additional plugins for XCP-ng
 Name: xcp-ng-xapi-plugins
-Version: 1.7.2
+Version: 1.8.0
 Release: 1%{?dist}
 URL: https://github.com/xcp-ng/xcp-ng-xapi-plugins
 Source0: https://github.com/xcp-ng/xcp-ng-xapi-plugins/archive/v%{version}/%{name}-%{version}.tar.gz
@@ -32,6 +32,12 @@ install SOURCES/etc/xapi.d/plugins/xcpngutils/*.py %{buildroot}/etc/xapi.d/plugi
 %dir /var/lib/xcp-ng-xapi-plugins
 
 %changelog
+* Tue Jun 06 2023 Ronan Abhamon <ronan.abhamon@vates.fr> - 1.8.0-1
+- Add LVM plugin to list and create PVs, VGs and LVs
+- RAID plugin: handle gracefully when no RAID is present
+- Add a way to install packages with updater.py
+- xcp-ng-linstor is now a default repo of updater.py
+
 * Fri May 20 2022 Benjamin Reis <benjamin.reis@vates.fr> - 1.7.2-1
 - Really disable unwanted repos when running yum update
 - Fix exception handling when a command fails
@@ -80,4 +86,3 @@ install SOURCES/etc/xapi.d/plugins/xcpngutils/*.py %{buildroot}/etc/xapi.d/plugi
 
 * Fri Jun 29 2018 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.0.0-1
 - Initial package.
-


### PR DESCRIPTION
- Add LVM plugin to list and create PVs, VGs and LVs
- RAID plugin: handle gracefully when no RAID is present
- Add a way to install packages with updater.py
- xcp-ng-linstor is now a default repo of updater.py