### PR TITLE
Update to 1.8.0

### DIFF
--- a/SOURCES/xcp-ng-xapi-plugins-1.7.3.tar.gz
+++ b/SOURCES/xcp-ng-xapi-plugins-1.7.3.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4068849e1627e89bd56da9e0d043b01e083340537b2aad8ecc2e49f0f2116cab
-size 32301

--- a/SOURCES/xcp-ng-xapi-plugins-1.8.0.tar.gz
+++ b/SOURCES/xcp-ng-xapi-plugins-1.8.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d609557bef31038c5412ca0a0dbb05a68371dbb6c222bece226a17b75b19585b
+size 32647

--- a/SPECS/xcp-ng-xapi-plugins.spec
+++ b/SPECS/xcp-ng-xapi-plugins.spec
@@ -1,6 +1,6 @@
 Summary: XAPI additional plugins for XCP-ng
 Name: xcp-ng-xapi-plugins
-Version: 1.7.3
+Version: 1.8.0
 Release: 1%{?dist}
 URL: https://github.com/xcp-ng/xcp-ng-xapi-plugins
 Source0: https://github.com/xcp-ng/xcp-ng-xapi-plugins/archive/v%{version}/%{name}-%{version}.tar.gz
@@ -32,7 +32,13 @@ install SOURCES/etc/xapi.d/plugins/xcpngutils/*.py %{buildroot}/etc/xapi.d/plugi
 %dir /var/lib/xcp-ng-xapi-plugins
 
 %changelog
+
+* Mon Jun 12 2023 Ronan Abhamon <ronan.abhamon@vates.fr> - 1.8.0-1
+- Add a way to install packages with updater.py
+- xcp-ng-linstor is now a default repo of updater.py
+
 * Fri Feb 03 2023 Benjamin Reis <benjamin.reis@vates.fr> - 1.7.3-1
+- Add LVM plugin to list and create PVs, VGs and LVs
 - RAID plugin: handle gracefully when no RAID is present
 
 * Fri Sep 16 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.7.2-2
@@ -86,4 +92,3 @@ install SOURCES/etc/xapi.d/plugins/xcpngutils/*.py %{buildroot}/etc/xapi.d/plugi
 
 * Fri Jun 29 2018 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.0.0-1
 - Initial package.
-


### PR DESCRIPTION
- Add a way to install packages with updater.py
- xcp-ng-linstor is now a default repo of updater.py