### PR TITLE
Update to 1.9.1: fix issue with smartctl plugin

### DIFF
--- a/SOURCES/xcp-ng-xapi-plugins-1.9.0.tar.gz
+++ b/SOURCES/xcp-ng-xapi-plugins-1.9.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a6f5dfa44f8d405aad2202e72a3d97e4808efa15f6847a8007a1a000b97b896e
-size 33909

--- a/SOURCES/xcp-ng-xapi-plugins-1.9.1.tar.gz
+++ b/SOURCES/xcp-ng-xapi-plugins-1.9.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46d791a28d1212a93e3ec6f55e656dd24eb5c8988cd1ac3939b236d197efe29b
+size 33901

--- a/SPECS/xcp-ng-xapi-plugins.spec
+++ b/SPECS/xcp-ng-xapi-plugins.spec
@@ -1,6 +1,6 @@
 Summary: XAPI additional plugins for XCP-ng
 Name: xcp-ng-xapi-plugins
-Version: 1.9.0
+Version: 1.9.1
 Release: 1%{?dist}
 URL: https://github.com/xcp-ng/xcp-ng-xapi-plugins
 Source0: https://github.com/xcp-ng/xcp-ng-xapi-plugins/archive/v%{version}/%{name}-%{version}.tar.gz
@@ -32,6 +32,9 @@ install SOURCES/etc/xapi.d/plugins/xcpngutils/*.py %{buildroot}/etc/xapi.d/plugi
 %dir /var/lib/xcp-ng-xapi-plugins
 
 %changelog
+* Wed Dec 20 2023 Guillaume Thouvenin <guillaume.thouvenin@vates.tech> - 1.9.1-1
+- Some devices don't support SMART capability. In this case just return the error
+
 * Mon Sep 25 2023 Benjamin Reis <benjamin.reis@vates.fr> - 1.9.0-1
 - Add smartctl plugin to get information and health of physical disks on the host
 


### PR DESCRIPTION
Return the information to client even if the smartctl command has an issue. The error is reported in the JSON output.